### PR TITLE
0.10.7 - Fix erosion and landslides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groundhog",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "homepage": "https://charredutensil.github.io/groundhog",
   "private": true,
   "dependencies": {

--- a/src/core/transformers/04_ephemera/05_serialize.ts
+++ b/src/core/transformers/04_ephemera/05_serialize.ts
@@ -47,7 +47,7 @@ function pointSet(points: Point[], [ox, oy]: Point, mode: "xy" | "yx"): string {
       const ys = (y + oy).toFixed();
       return mode === "xy" ? `${xs},${ys}/` : `${ys},${xs}/`;
     })
-    .join();
+    .join("");
 }
 
 function grid(


### PR DESCRIPTION
Erosion and landslides haven't been working properly. At most one erosion tile was generated on the entire map due to a malformed serialization.